### PR TITLE
Release inferno v1.0.1

### DIFF
--- a/.github/workflows/aggregate.yaml
+++ b/.github/workflows/aggregate.yaml
@@ -42,11 +42,9 @@ jobs:
 
       - name: Commit GQL cache
         if: always()
-        uses: github-actions-x/commit@v2.9
+        uses: actions-x/commit@v6
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          push-branch: "production"
-          commit-message: "chore(gql cache): updates the cached blocks PE-1270"
-          files: cache
-          name: Github Action
-          email: info@ardrive.io
+          name: GitHub Actions Cache Committer
+          branch: production
+          files: ./cache
+          message: "chore(gql cache): updates the cached blocks PE-1270"

--- a/.github/workflows/aggregate.yaml
+++ b/.github/workflows/aggregate.yaml
@@ -1,13 +1,12 @@
-
 name: Aggregate daily data
-on: 
+on:
   schedule:
     # at 6AM, 12AM, 6PM, and  12PM UTC
     # at 2AM, 8AM, 2PM, and  8PM EST
-    - cron: '0 6/6 * * *'
+    - cron: "0 6/6 * * *"
 
 jobs:
-  test-and-build:
+  aggregate:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -41,3 +40,13 @@ jobs:
       - name: Publish output
         run: ardrive upload-file --local-path ./daily_output.json -F "d62a47c3-0b9d-4442-ac72-252a239d0469" -w /tmp/wallet --no-bundle --upsert
 
+      - name: Commit GQL cache
+        if: always()
+        uses: github-actions-x/commit@v2.9
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          push-branch: "production"
+          commit-message: "chore(gql cache): updates the cached blocks PE-1270"
+          files: cache
+          name: Github Action
+          email: info@ardrive.io

--- a/.github/workflows/aggregate.yaml
+++ b/.github/workflows/aggregate.yaml
@@ -8,6 +8,9 @@ on:
 
 jobs:
   aggregate:
+    concurrency:
+      group: ${{ github.workflow }}
+      cancel-in-progress: true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -36,7 +39,16 @@ jobs:
         run: ardrive download-file -f 7fa5d4e3-0087-422a-acb3-2e481d98d08b
 
       - name: Run
-        run: yarn node ./lib/index.js aggregate
+        run: |
+          EXITCODE=1 && while [ $EXITCODE -eq 1 ]; do
+            yarn node ./lib/index.js aggregate;
+            EXITCODE=$?;
+            echo "Exit code: $EXITCODE";
+            if [ $EXITCODE -eq 1 ]; then
+              echo "The script will run again after a cooldown time of 30 minutes"
+              sleep 1800 # half an hour (60 * 30 seconds)
+            fi
+          done
 
       - name: Publish output
         run: ardrive upload-file --local-path ./daily_output.json -F "d62a47c3-0b9d-4442-ac72-252a239d0469" -w /tmp/wallet --no-bundle --upsert

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "inferno-backend",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"description": "A token distributor for the Inferno Rewards program",
 	"main": "src/index.ts",
 	"repository": "git@github.com:ardriveapp/inferno-backend.git",


### PR DESCRIPTION
Changelog:
- Makes the GH Action to commit the cached blocks
- Loop the aggregation script until it exits with no error or another job started, with a cooldown of 30 minutes