### PR TITLE
PE-2771: read app tags iteratively instead of just the first match

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "inferno-backend",
-	"version": "1.5.0",
+	"version": "1.6.0",
 	"description": "A token distributor for the Inferno Rewards program",
 	"main": "src/index.ts",
 	"repository": "git@github.com:ardriveapp/inferno-backend.git",

--- a/src/common.ts
+++ b/src/common.ts
@@ -197,11 +197,18 @@ export const ardriveOracle = new ArDriveContractOracle([
 export async function validateTxTip(node: GQLNodeInterface, ardriveOracle: ArDriveContractOracle): Promise<boolean> {
 	const tags = node.tags;
 	const boostValue = +(tags.find((tag) => tag.name === BOOST_TAG)?.value || '1');
-	const appName = tags.find((tag) => tag.name === APP_NAME_TAG)?.value;
-	const appVersion = tags.find((tag) => tag.name === APP_VERSION_TAG)?.value;
+	const appNameTags = tags.filter((tag) => tag.name === APP_NAME_TAG);
+	const appVersionTags = tags.filter((tag) => tag.name === APP_VERSION_TAG);
 	const bundledIn = node.bundledIn;
+
 	const isV2Tx = !bundledIn;
-	if (appName === WEB_APP_NAME && appVersion && !isSemanticVersionGreaterThan(appVersion, '1.14.1') && isV2Tx) {
+	const isWebApp = appNameTags.some((appNameTag) => appNameTag.value === WEB_APP_NAME);
+	const isAppVersionGreaterThan1_14_1 = appVersionTags.some((appVersionTag) =>
+		// FIXME: this way of doing it cannot distinguish between multiple apps' version
+		// might result in false positives
+		isSemanticVersionGreaterThan(appVersionTag.value, '1.14.1')
+	);
+	if (isWebApp && !isAppVersionGreaterThan1_14_1 && isV2Tx) {
 		// we ignore web v2 transactions' tip as it's not possible to validate
 		return true;
 	}

--- a/src/common.ts
+++ b/src/common.ts
@@ -206,6 +206,8 @@ export async function validateTxTip(node: GQLNodeInterface, ardriveOracle: ArDri
 	const isAppVersionGreaterThan1_14_1 = appVersionTags.some((appVersionTag) =>
 		// FIXME: this way of doing it cannot distinguish between multiple apps' version
 		// might result in false positives
+
+		// We are good until we bump version of the second app (eg smartweave), and it's greater than 1.14.1
 		isSemanticVersionGreaterThan(appVersionTag.value, '1.14.1')
 	);
 	if (isWebApp && !isAppVersionGreaterThan1_14_1 && isV2Tx) {

--- a/src/daily_output.ts
+++ b/src/daily_output.ts
@@ -267,9 +267,14 @@ export class DailyOutput {
 		const queryDate = new Date(queryTimestamp);
 
 		// x2 data count for Mobile
-		const appName = tags.find((tag) => tag.name === 'App-Name')?.value;
+		const appNameTags = tags.filter((tag) => tag.name === 'App-Name');
 		const appPlatform = tags.find((tag) => tag.name === 'App-Platform')?.value;
-		const dataSizeDoubledForMobile = this.doublesData(queryDate, appName, appPlatform) ? dataSize * 2 : dataSize;
+		const dataSizeDoubledForMobile = appNameTags.reduce(
+			(accumulator, appNameTag) => accumulator || this.doublesData(queryDate, appNameTag.value, appPlatform),
+			false
+		)
+			? dataSize * 2
+			: dataSize;
 
 		if (fee && isTipValid && (isV2DataTx || isBundleTransaction)) {
 			const previousTimestamp = this.latestTimestamp * 1000;

--- a/src/utils/layer_1_helpers.ts
+++ b/src/utils/layer_1_helpers.ts
@@ -2,7 +2,7 @@ import { createHash } from 'crypto';
 import { APP_NAME_TAG, VALID_APP_NAMES } from '../constants';
 import { GQLEdgeInterface, GQLTagInterface } from '../gql_types';
 
-export function ardriveTxFilter(edge: GQLEdgeInterface) {
+export function ardriveTxFilter(edge: GQLEdgeInterface): boolean {
 	const appNameTags = edge.node.tags.filter((tag) => tag.name === APP_NAME_TAG);
 	return VALID_APP_NAMES.some((validAppName) => appNameTags.find((tag) => tag.value === validAppName));
 }
@@ -21,11 +21,11 @@ export function decodeTags(encodedTags: GQLTagInterface[]): GQLTagInterface[] {
 	return tags;
 }
 
-export function sha256B64Url(input: Buffer) {
+export function sha256B64Url(input: Buffer): string {
 	return toB64url(createHash('sha256').update(input).digest());
 }
 
-export function toB64url(buffer: Buffer) {
+export function toB64url(buffer: Buffer): string {
 	return buffer.toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
 }
 

--- a/src/utils/layer_1_helpers.ts
+++ b/src/utils/layer_1_helpers.ts
@@ -3,8 +3,8 @@ import { APP_NAME_TAG, VALID_APP_NAMES } from '../constants';
 import { GQLEdgeInterface, GQLTagInterface } from '../gql_types';
 
 export function ardriveTxFilter(edge: GQLEdgeInterface) {
-	const appName = edge.node.tags.find((tag) => tag.name === APP_NAME_TAG)?.value;
-	return !!appName && VALID_APP_NAMES.includes(appName);
+	const appNameTags = edge.node.tags.filter((tag) => tag.name === APP_NAME_TAG);
+	return VALID_APP_NAMES.some((validAppName) => appNameTags.find((tag) => tag.value === validAppName));
 }
 
 export function decodeTags(encodedTags: GQLTagInterface[]): GQLTagInterface[] {


### PR DESCRIPTION
Changes
- Reads the App Tags iteratively. Previously only the first match would be checked.

Extra :-)
- Explicitly sets the missing type of some methods