### PR TITLE
PE-2806: track the partial changes of canceled runs as well

### DIFF
--- a/.github/workflows/aggregate.yaml
+++ b/.github/workflows/aggregate.yaml
@@ -37,10 +37,24 @@ jobs:
             - name: Fetch previous output
               run: ardrive download-file -f 7fa5d4e3-0087-422a-acb3-2e481d98d08b
 
+            - name: Copy the initial output
+              run: cp ./daily_output.json ./daily_output_initial.json
+
             - name: Run
               run: bash ".github/workflows/aggregate.sh"
 
+            # https://github.com/orgs/community/discussions/27148#discussioncomment-3254824
+            # is this the correct way of setting an action env var?
+            - name: Check for changes in the output
+              run: |
+                if [ "$(jq -n --argjson a "´cat ./daily_output.json´" --argjson b "´cat ./daily_output_initial.json´" '$a != $b')" -eq "true" ]; then
+                  echo "::set-env name=changes_exist::true"
+                else
+                  echo "::set-env name=changes_exist::false"
+                fi
+
             - name: Publish output
+              if: ${{ env.changes_exist == 'true' }}
               run: ardrive upload-file --local-path ./daily_output.json -F "d62a47c3-0b9d-4442-ac72-252a239d0469" -w /tmp/wallet --no-bundle --upsert
 
             - name: Commit GQL cache

--- a/.github/workflows/aggregate.yaml
+++ b/.github/workflows/aggregate.yaml
@@ -40,7 +40,7 @@ jobs:
             - name: Copy the initial output
               run: cp ./daily_output.json ./daily_output_initial.json
 
-            - name: Run
+            - name: Run the aggregate command
               run: bash ".github/workflows/aggregate.sh"
 
             - name: Check for changes in the output

--- a/.github/workflows/aggregate.yaml
+++ b/.github/workflows/aggregate.yaml
@@ -46,6 +46,7 @@ jobs:
             # https://github.com/orgs/community/discussions/27148#discussioncomment-3254824
             # is this the correct way of setting an action env var?
             - name: Check for changes in the output
+              if: always()
               run: |
                 if [ "$(jq -n --argjson a "´cat ./daily_output.json´" --argjson b "´cat ./daily_output_initial.json´" '$a != $b')" -eq "true" ]; then
                   echo "::set-env name=changes_exist::true"

--- a/.github/workflows/aggregate.yaml
+++ b/.github/workflows/aggregate.yaml
@@ -43,19 +43,14 @@ jobs:
             - name: Run
               run: bash ".github/workflows/aggregate.sh"
 
-            # https://github.com/orgs/community/discussions/27148#discussioncomment-3254824
-            # is this the correct way of setting an action env var?
             - name: Check for changes in the output
               if: always()
               run: |
-                if [ "$(jq -n --argjson a "´cat ./daily_output.json´" --argjson b "´cat ./daily_output_initial.json´" '$a != $b')" -eq "true" ]; then
-                  echo "::set-env name=changes_exist::true"
-                else
-                  echo "::set-env name=changes_exist::false"
-                fi
+                IS_THERE_DIFF="$(jq -n --argjson a "$(cat ./daily_output.json)" --argjson b "$(cat ./daily_output_initial.json)" '$a != $b')" \
+                echo "::set-env name=OUTPUT_HAS_CHANGED::$IS_THERE_DIFF" // vs. export OUTPUT_HAS_CHANGED="$IS_THERE_DIFF" (?)
 
             - name: Publish output
-              if: ${{ env.changes_exist == 'true' }}
+              if: ${{ env.OUTPUT_HAS_CHANGED == 'true' }}
               run: ardrive upload-file --local-path ./daily_output.json -F "d62a47c3-0b9d-4442-ac72-252a239d0469" -w /tmp/wallet --no-bundle --upsert
 
             - name: Commit GQL cache

--- a/src/daily_output.test.ts
+++ b/src/daily_output.test.ts
@@ -44,7 +44,7 @@ describe('DailyOutput class', () => {
 
 		it('Throws if the previous block height is ahead of some query result', () => {
 			return expectAsyncErrorThrow({
-				promiseToError: output.feedGQLData([
+				promiseToError: output.writeOutputFrom([
 					{
 						cursor: '914100',
 						node: {

--- a/src/daily_output.ts
+++ b/src/daily_output.ts
@@ -57,6 +57,8 @@ export class DailyOutput {
 			if (edge.node.block.height && this.currentHieght !== edge.node.block.height) {
 				// only after we find a new block, because we are sure that there are no more transactions belonging to an already found bundle
 				await this.finishDataAggregation();
+
+				this.write();
 			}
 		}
 	}
@@ -77,6 +79,7 @@ export class DailyOutput {
 		bundleTxIDs.forEach((txId) => {
 			if (!this.bundleFileCount[txId]) {
 				this.sumFile(this.bundlesTips[txId].address);
+				delete this.bundlesTips[txId];
 			}
 		});
 
@@ -122,8 +125,6 @@ export class DailyOutput {
 			this.resetWalletDay(address);
 		}
 		this.resetRanksDay();
-
-		this.write();
 	}
 
 	private caclulateWeeklyRewards(): void {
@@ -187,8 +188,6 @@ export class DailyOutput {
 		}
 		this.updateTotalRewards();
 		this.resetRanksWeek();
-
-		this.write();
 	}
 
 	private caclulateTotalRanks(): void {

--- a/src/daily_output.ts
+++ b/src/daily_output.ts
@@ -51,15 +51,15 @@ export class DailyOutput {
 	 */
 	public async feedGQLData(queryResult: GQLEdgeInterface[]): Promise<void> {
 		for (const edge of queryResult) {
-			await this.aggregateData(edge);
-
-			this.currentHieght = edge.node.block.height;
 			if (edge.node.block.height && this.currentHieght !== edge.node.block.height) {
 				// only after we find a new block, because we are sure that there are no more transactions belonging to an already found bundle
 				await this.finishDataAggregation();
 
 				this.write();
 			}
+			this.currentHieght = edge.node.block.height;
+
+			await this.aggregateData(edge);
 		}
 	}
 

--- a/src/daily_output.ts
+++ b/src/daily_output.ts
@@ -61,6 +61,10 @@ export class DailyOutput {
 
 			await this.aggregateData(edge);
 		}
+
+		this.data.blockHeight = this.heightRange[1];
+		// Should we await this.finishDataAggregation(); at this point?
+		this.write();
 	}
 
 	/**
@@ -72,8 +76,6 @@ export class DailyOutput {
 	 * - streak rewards
 	 */
 	private async finishDataAggregation(): Promise<void> {
-		console.log(`Finishing data aggregation...`);
-
 		// aggregate +1 file count to the non unbundled bundles
 		const bundleTxIDs = Object.keys(this.bundlesTips);
 		bundleTxIDs.forEach((txId) => {
@@ -84,7 +86,7 @@ export class DailyOutput {
 		});
 
 		// calculate change in percentage of the uploaded data and rank position
-		this.data.blockHeight = this.heightRange[1];
+		this.data.blockHeight = this.currentHieght;
 		this.data.timestamp = this.latestTimestamp;
 
 		this.caclulateChangeOfUploadVolume();

--- a/src/gql_cache.ts
+++ b/src/gql_cache.ts
@@ -174,6 +174,8 @@ export class GQLCache {
 		if (!this.cacheFolderExists) {
 			return [];
 		}
+
+		// These are not sorted (these are, but the OS is doing the job, might differ within different platforms)
 		const listResult = readdirSync(CACHE_FOLDER);
 		return listResult;
 	}

--- a/src/index.ts
+++ b/src/index.ts
@@ -82,6 +82,7 @@ async function aggregateOutputData(minBlock?: number, maxBlock?: number): Promis
 	const PSTHolders = await getWalletsEligibleForStreak();
 	await output.feedPSTHolders(PSTHolders);
 	const edges = await getAllArDriveTransactionsWithin(new HeightRange(minimumBlock, maximumBlock));
+
+	// TODO: Could take instead a stream
 	await output.feedGQLData(edges);
-	output.write();
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,7 +76,7 @@ function run(): void {
  * @param maxBlock an integer representing the block until where to query the data
  */
 async function aggregateOutputData(minBlock?: number, maxBlock?: number): Promise<void> {
-	const minimumBlock = minBlock ?? getMinBlockHeight();
+	const minimumBlock = minBlock || getMinBlockHeight();
 	const maximumBlock = maxBlock ?? (await getBlockHeight());
 	const output = new DailyOutput([minimumBlock, maximumBlock]);
 	const PSTHolders = await getWalletsEligibleForStreak();

--- a/src/index.ts
+++ b/src/index.ts
@@ -84,5 +84,5 @@ async function aggregateOutputData(minBlock?: number, maxBlock?: number): Promis
 	const edges = await getAllArDriveTransactionsWithin(new HeightRange(minimumBlock, maximumBlock));
 
 	// TODO: Could take instead a stream
-	await output.feedGQLData(edges);
+	await output.writeOutputFrom(edges);
 }

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -52,7 +52,7 @@ async function getStakedPSTHolders(): Promise<StakedPSTHolders> {
  */
 export async function getAllArDriveTransactionsWithin(range: HeightRange): Promise<GQLEdgeInterface[]> {
 	const cache = new GQLCache(range);
-	const nonCachedRanges = cache.getNonCachedRangesWithin().reverse();
+	const nonCachedRanges = cache.getNonCachedRangesWithin();
 
 	console.log('Height ranges to query are', nonCachedRanges.length);
 


### PR DESCRIPTION
Now, on each block iteration the output is persisted. Then at the end of the "Run" (the aggregation script) Job, the last persisted output is published to the Inferno Stats drive (only if there was changes, won't do if not), even if the action was stopped or if there was a memory overflow.

Changes
- Writes to disk the changes on every new iterated block
- Makes the GH Action to:
  - duplicate the initial daily_output JSON to be later compared;
  - after the command is stopped (either failed or succeed), conditionally upload the output if there was changes